### PR TITLE
Add a link for retrieving current geographic coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 ### 注意
 
 请使用 Mapbox 的[显示经纬度](https://www.mapbox.com/mapbox.js/example/v1.0.0/select-center-form/)来获取经纬度，在 Google Maps 上通过 What’s here 取得的经纬度有些许偏差。
+如果你正在咖啡馆并且可以翻墙，可以使用 [whereami](https://xavierchow.github.io/whereami/) 来获得当前经纬度。
 
 ## 授权
 [CC-BY](http://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
A deadly simple web site to get current geographic coordinates, it's based on [mapbox.js](https://www.mapbox.com/mapbox.js/api/v2.3.0/) and html5 [geolocation](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation) thus should be no offset for OSM, the only requirement is you have to be able to access the google geo api which's blocked by the infamous GFW.
